### PR TITLE
Improve parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ subprojects {
     group = "com.megatome.javadoc2dash"
 
     def javaApiUrl = 'http://docs.oracle.com/javase/1.7.0/docs/api/'
-    def groovyApiUrl = 'http://groovy.codehaus.org/gapi/'
+    def groovyApiUrl = 'http://groovy-lang.org/gapi/'
     tasks.withType(Javadoc) {
         options.links(javaApiUrl, groovyApiUrl)
     }

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/DBSupportTest.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/DBSupportTest.java
@@ -45,12 +45,12 @@ public class DBSupportTest {
         final File dbFile = getFile(dbDir, "docSet.dsidx");
         assertTrue("DB file does not exist", dbFile.exists());
 
-        final Map<MatchType, Integer> expectedTypes = ExpectedDataUtil.getExpectedData().getExpectedTypes();
+        final Map<String, Integer> expectedTypes = ExpectedDataUtil.getExpectedData().getExpectedDataBaseTypes();
         try (final Connection connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile);
              final PreparedStatement stmt = connection.prepareStatement(QUERY)){
 
-            for (Map.Entry<MatchType, Integer> expectedEntry : expectedTypes.entrySet()) {
-                stmt.setString(1, expectedEntry.getKey().getTypeName());
+            for (Map.Entry<String, Integer> expectedEntry : expectedTypes.entrySet()) {
+                stmt.setString(1, expectedEntry.getKey());
                 try (final ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {
                         final int count = rs.getInt(1);

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/ExpectedDataUtil.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/ExpectedDataUtil.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public class ExpectedDataUtil {
     private final Map<MatchType, Integer> EXPECTED_TYPES = new HashMap<>();
+    private final Map<String, Integer> EXPECTED_DATABASE_TYPES = new HashMap<>();
     private int EXPECTED_ENTRY_COUNT = 0;
 
     private static final ExpectedDataUtil INSTANCE = new ExpectedDataUtil();
@@ -26,6 +27,15 @@ public class ExpectedDataUtil {
         for (final Integer count : EXPECTED_TYPES.values()) {
             EXPECTED_ENTRY_COUNT += count;
         }
+
+        for (final Map.Entry<MatchType, Integer> entry : EXPECTED_TYPES.entrySet()) {
+            final String dbColumnName = entry.getKey().getTypeName();
+            int count = entry.getValue();
+            if (EXPECTED_DATABASE_TYPES.containsKey(dbColumnName)) {
+                count += EXPECTED_DATABASE_TYPES.get(dbColumnName);
+            }
+            EXPECTED_DATABASE_TYPES.put(dbColumnName, count);
+        }
     }
 
     public static ExpectedDataUtil getExpectedData() {
@@ -34,6 +44,10 @@ public class ExpectedDataUtil {
 
     public Map<MatchType, Integer> getExpectedTypes() {
         return Collections.unmodifiableMap(EXPECTED_TYPES);
+    }
+
+    public Map<String, Integer> getExpectedDataBaseTypes() {
+        return Collections.unmodifiableMap(EXPECTED_DATABASE_TYPES);
     }
 
     public int getExpectedEntryCount() {

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/ExpectedDataUtil.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/ExpectedDataUtil.java
@@ -14,13 +14,14 @@ public class ExpectedDataUtil {
         EXPECTED_TYPES.put(MatchType.CLASS, 1);
         EXPECTED_TYPES.put(MatchType.INTERFACE, 1);
         EXPECTED_TYPES.put(MatchType.CONSTRUCTOR, 5);
-        EXPECTED_TYPES.put(MatchType.METHOD, 5);
+        EXPECTED_TYPES.put(MatchType.METHOD, 2);
         EXPECTED_TYPES.put(MatchType.PACKAGE, 6);
         EXPECTED_TYPES.put(MatchType.EXCEPTION, 1);
         EXPECTED_TYPES.put(MatchType.ERROR, 1);
         EXPECTED_TYPES.put(MatchType.FIELD, 1);
         EXPECTED_TYPES.put(MatchType.ENUM, 1);
         EXPECTED_TYPES.put(MatchType.NOTATION, 1);
+        EXPECTED_TYPES.put(MatchType.STATIC_METHOD, 3);
 
         for (final Integer count : EXPECTED_TYPES.values()) {
             EXPECTED_ENTRY_COUNT += count;


### PR DESCRIPTION
I'm putting this one up for your consideration.

I was noticing that none of the fields and methods were getting indexed, so I know there's something up with parsing class files.

I think it's the same issue with the tag name that I fix here for index files.

When climbing out of a style tag, like ``<span>``, the code wasn't updating the tag name, and so was missing the entries in the index files. Classes and interfaces were working because they have unstyled links in the explanation of an entry.

With the change to JavadocSupport at like 126, the parser now notices the bold links in the ``index-all.html`` file, and finds all the methods and fields, etc.

Comparing our large code base, with this change and #10, the counts for the search index types are identical with the Objective-C javadocset command.

Since it's kind of an architectural change as well, I'm curious for your input as how to best proceed.

If you like, I'll clean up the commented code.

Thanks again for writing this code!