### PR TITLE
Open javadoc2dash for custom HTML to DashDocset conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,9 @@ Bare minimum: `j2d-cli --name Sample --javadoc /path/to/apidoc`
 Full options: `j2d-cli --name Sample --javadoc /path/to/apidoc --displayName "Awesome Sample API" --keyword asa --iconFile /path/to/icon.png --out /path/to/output`
 
 Abbreviated options. Most command-line options can be abbreviated. `j2d-cli -n Sample -j /path/to/apidoc -d "Awesome Sample API" -k asa -i /path/to/icon.png -o /path/to/output`
+
+# Custom HTML to DashDocset generation
+
+The plugin supports the implementation of a custom Dash Docset where the search properties can be generated at will. The default JavaDoc DashDocset is basically a specific implementation. To create a custom docset out of any HTML you need to implement the DocSetParserInterface and the MatchTypeInterface.
+
+An example for JSDoc3 can be found at [https://github.com/i-net-software/jsdoc-dash-docset](https://github.com/i-net-software/jsdoc-dash-docset)

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-ext.projectVersion = '1.1.0'
+ext.projectVersion = '1.2.0'
 ext.projectLocation = "https://github.com/iamthechad/javadoc2dash"
 
 apply plugin: 'com.github.kt3k.coveralls'

--- a/j2d-gradle/src/main/groovy/com/megatome/javadoc2dash/Javadoc2DashPlugin.groovy
+++ b/j2d-gradle/src/main/groovy/com/megatome/javadoc2dash/Javadoc2DashPlugin.groovy
@@ -2,6 +2,7 @@ package com.megatome.javadoc2dash
 
 import com.megatome.javadoc2dash.tasks.Javadoc2DashFeedTask
 import com.megatome.javadoc2dash.tasks.Javadoc2DashTask
+import com.megatome.j2d.support.DocSetParserInterface
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
@@ -31,6 +32,7 @@ class Javadoc2DashPlugin implements Plugin<Project> {
             conventionMapping.javadocRoot = { baseExtension.javadocRoot }
             conventionMapping.outputLocation = { baseExtension.outputLocation }
             conventionMapping.iconFile = { baseExtension.iconFile }
+            conventionMapping.implementation = { baseExtension.implementation }
         }
 
         def feedExtension = project.extensions.findByName(FEED_EXTENSION_NAME)
@@ -69,6 +71,7 @@ class Javadoc2DashPluginExtension {
     String keyword
     File iconFile
     String javadocTask
+    DocSetParserInterface implementation
 
     Javadoc2DashPluginExtension(Project project) {
         docsetName = project.name
@@ -77,6 +80,7 @@ class Javadoc2DashPluginExtension {
         javadocRoot = project.file("${project.docsDir}/javadoc")
         outputLocation = project.file("${project.buildDir}/javadoc2dash")
         iconFile = null
+        implementation = null
         javadocTask = "javadoc"
     }
 }

--- a/j2d-gradle/src/main/groovy/com/megatome/javadoc2dash/tasks/Javadoc2DashTask.groovy
+++ b/j2d-gradle/src/main/groovy/com/megatome/javadoc2dash/tasks/Javadoc2DashTask.groovy
@@ -1,6 +1,7 @@
 package com.megatome.javadoc2dash.tasks
 
 import com.megatome.j2d.DocsetCreator
+import com.megatome.j2d.support.DocSetParserInterface
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
@@ -18,6 +19,10 @@ class Javadoc2DashTask extends DefaultTask {
     @Optional
     File iconFile
 
+    @Input
+    @Optional
+    DocSetParserInterface implementation
+
     Javadoc2DashTask() {
         this.description = 'Create a Dash docset from Javadoc';
         group = 'Javadoc2Dash'
@@ -31,6 +36,7 @@ class Javadoc2DashTask extends DefaultTask {
                 .keyword(keyword)
                 .outputDirectory(outputLocation)
                 .iconFile(iconFile)
+                .implementation(implementation)
             DocsetCreator creator = builder.build()
             creator.makeDocset()
         }

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/support/DBSupport.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/support/DBSupport.java
@@ -15,14 +15,18 @@
  */
 package com.megatome.j2d.support;
 
-import com.megatome.j2d.exception.BuilderException;
-import com.megatome.j2d.util.SearchIndexValue;
-
-import java.sql.*;
-import java.util.List;
-
 import static com.megatome.j2d.util.LogUtility.logVerbose;
 import static org.apache.commons.io.FilenameUtils.concat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+import com.megatome.j2d.exception.BuilderException;
+import com.megatome.j2d.util.SearchIndexValue;
 
 /**
  * Utility class for SQLite DB manipulation of the docset.
@@ -39,7 +43,7 @@ public final class DBSupport {
      * Create a new DB file, and insert all of the specified index values.
      * @param indexValues Index values to insert into the DB
      * @param dbFileDir Directory to create the DB file in.
-     * @throws BuilderException
+     * @throws BuilderException in case of errors
      */
     public static void createIndex(List<SearchIndexValue> indexValues, String dbFileDir) throws BuilderException {
 

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/support/DocSetParserInterface.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/support/DocSetParserInterface.java
@@ -1,0 +1,28 @@
+package com.megatome.j2d.support;
+
+import java.io.File;
+import java.util.List;
+
+import com.megatome.j2d.exception.BuilderException;
+import com.megatome.j2d.util.IndexData;
+import com.megatome.j2d.util.SearchIndexValue;
+
+public interface DocSetParserInterface {
+
+    /**
+     * Find the file to be used as the docset index and locate all Javadoc files to be indexed.
+     * @param javadocDir Directory where the Javadoc is located
+     * @return IndexData object
+     * @throws BuilderException in case of errors
+     * @see IndexData
+     */
+    abstract public IndexData findIndexFile(File javadocDir) throws BuilderException;
+
+    /**
+     * Find all values to be indexed within the specified list of files.
+     * @param filesToIndex List of Javadoc files to parse
+     * @return List of relevant values to be indexed in the docset
+     * @throws BuilderException in case of errors
+     */
+    abstract public List<SearchIndexValue> findSearchIndexValues(List<File> filesToIndex) throws BuilderException;
+}

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/support/DocSetSupport.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/support/DocSetSupport.java
@@ -15,14 +15,19 @@
  */
 package com.megatome.j2d.support;
 
-import com.megatome.j2d.exception.BuilderException;
+import static com.megatome.j2d.util.LogUtility.logVerbose;
+import static org.apache.commons.io.FileUtils.copyDirectory;
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.apache.commons.io.FileUtils.forceMkdir;
+import static org.apache.commons.io.FileUtils.getFile;
+import static org.apache.commons.io.FileUtils.write;
+import static org.apache.commons.io.FilenameUtils.concat;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.apache.commons.io.FileUtils.*;
-import static org.apache.commons.io.FilenameUtils.concat;
-import static com.megatome.j2d.util.LogUtility.*;
+import com.megatome.j2d.exception.BuilderException;
 
 /**
  * Utility class for operations on the docset.
@@ -41,7 +46,7 @@ public class DocSetSupport {
     /**
      * Create the docset package. Will delete an existing docset if one already exists at the specified location.
      * @param docsetDir Location of the docset to create
-     * @throws BuilderException
+     * @throws BuilderException in case of errors
      */
     public static void createDocSetStructure(String docsetDir) throws BuilderException {
         final File docsetRootDir = getFile(getDocsetRoot(docsetDir));
@@ -68,7 +73,7 @@ public class DocSetSupport {
      * Copy an icon file to the docset. If the file path is not specified, no error happens.
      * @param iconFile File to copy as the docset icon.
      * @param docsetDir Directory of the docset
-     * @throws BuilderException
+     * @throws BuilderException in case of errors
      */
     public static void copyIconFile(File iconFile, String docsetDir) throws BuilderException {
         if (null == iconFile) {
@@ -87,7 +92,7 @@ public class DocSetSupport {
      * Copy all files and folders from a source location into the docset.
      * @param sourceDir Source directory to copy from
      * @param docsetDir Directory of the docset
-     * @throws BuilderException
+     * @throws BuilderException in case of errors
      */
     public static void copyFiles(final String sourceDir, String docsetDir) throws BuilderException {
         copyFiles(getFile(sourceDir), docsetDir);
@@ -97,7 +102,7 @@ public class DocSetSupport {
      * Copy all files and folders from a source location into the docset.
      * @param sourceDir Source directory to copy from
      * @param docsetDir Directory of the docset
-     * @throws BuilderException
+     * @throws BuilderException in case of errors
      */
     public static void copyFiles(final File sourceDir, String docsetDir) throws BuilderException {
         try {
@@ -115,7 +120,7 @@ public class DocSetSupport {
      * @param keyword Keyword used for the docset in Dash
      * @param indexFile The file to be used as the docset index
      * @param docsetDir Directory of the docset
-     * @throws BuilderException
+     * @throws BuilderException in case of errors
      */
     public static void createPList(String bundleIdentifier, String displayName, String keyword, String indexFile, String docsetDir) throws BuilderException {
         final String plist = String.format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><dict><key>CFBundleIdentifier</key><string>%s</string><key>CFBundleName</key><string>%s</string><key>DocSetPlatformFamily</key><string>%s</string><key>dashIndexFilePath</key><string>%s</string><key>DashDocSetFamily</key><string>java</string><key>isDashDocset</key><true/></dict></plist>",

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/support/JavadocSupport.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/support/JavadocSupport.java
@@ -15,46 +15,41 @@
  */
 package com.megatome.j2d.support;
 
-import com.megatome.j2d.exception.BuilderException;
-import com.megatome.j2d.util.IndexData;
-import com.megatome.j2d.util.SearchIndexValue;
-import org.apache.commons.io.FileUtils;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
+import static com.megatome.j2d.util.LogUtility.logVerbose;
+import static org.apache.commons.io.FileUtils.getFile;
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static com.megatome.j2d.util.LogUtility.logVerbose;
-import static org.apache.commons.io.FileUtils.getFile;
-import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import org.apache.commons.io.FileUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.megatome.j2d.exception.BuilderException;
+import com.megatome.j2d.util.IndexData;
+import com.megatome.j2d.util.SearchIndexValue;
 
 /**
  * Utility class to support Javadoc related docset tasks.
  */
-public final class JavadocSupport {
+public final class JavadocSupport implements DocSetParserInterface {
     private static final Pattern parentPattern = Pattern.compile("span|code|i|b", Pattern.CASE_INSENSITIVE);
-    private static final List<MatchType> extraIndexingTypes = Arrays.asList(MatchType.CLASS, MatchType.INTERFACE, MatchType.ENUM, MatchType.EXCEPTION, MatchType.ERROR);
 
-    private JavadocSupport() {}
+    public JavadocSupport() {}
 
     /**
-     * Find the file to be used as the docset index and locate all Javadoc files to be indexed.
-     * @param javadocDir Directory where the Javadoc is located
-     * @return IndexData object
-     * @throws BuilderException
-     * @see IndexData
+     * {@inheritDoc}
      */
-    public static IndexData findIndexFile(File javadocDir) throws BuilderException {
+    @Override
+    public IndexData findIndexFile(File javadocDir) throws BuilderException {
         final IndexData indexData = new IndexData();
         if (!javadocDir.exists() || !javadocDir.isDirectory()) {
             throw new BuilderException(String.format("%s does not exist, or is not a directory", javadocDir.getAbsolutePath()));
@@ -91,12 +86,10 @@ public final class JavadocSupport {
     }
 
     /**
-     * Find all values to be indexed within the specified list of files.
-     * @param filesToIndex List of Javadoc files to parse
-     * @return List of relevant values to be indexed in the docset
-     * @throws BuilderException
+     * {@inheritDoc}
      */
-    public static List<SearchIndexValue> findSearchIndexValues(List<File> filesToIndex) throws BuilderException {
+    @Override
+    public List<SearchIndexValue> findSearchIndexValues(List<File> filesToIndex) throws BuilderException {
         final List<SearchIndexValue> values = new ArrayList<>();
         for (final File f : filesToIndex) {
             final List<SearchIndexValue> indexValues = indexFile(f);

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/support/MatchType.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/support/MatchType.java
@@ -15,16 +15,16 @@
  */
 package com.megatome.j2d.support;
 
+import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
-
 /**
  * Enumeration for matching types from parsed Javadoc files
  */
-public enum MatchType {
+public enum MatchType implements MatchTypeInterface {
     CLASS("Class", "class", "Class in", "- class"),
     STATIC_METHOD("Method", "method", "Static method in"),
     FIELD("Field", "field", "Static variable in", "Field in", "field.summary"),
@@ -49,6 +49,7 @@ public enum MatchType {
         this.classSuffix = classSuffix;
     }
 
+    @Override
     public String getTypeName() {
         return typeName;
     }

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/support/MatchTypeInterface.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/support/MatchTypeInterface.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 Megatome Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.megatome.j2d.support;
+
+/**
+ * Enumeration for matching type
+ */
+public interface MatchTypeInterface {
+
+    /**
+     * The name of the type corresponding to: https://kapeli.com/docsets#supportedentrytypes
+     * @return The name of the type
+     */
+    public String getTypeName();
+}

--- a/javadoc2dash-api/src/main/java/com/megatome/j2d/util/SearchIndexValue.java
+++ b/javadoc2dash-api/src/main/java/com/megatome/j2d/util/SearchIndexValue.java
@@ -15,14 +15,14 @@
  */
 package com.megatome.j2d.util;
 
-import com.megatome.j2d.support.MatchType;
+import com.megatome.j2d.support.MatchTypeInterface;
 
 /**
  * Represents information that needs to be saved to the docset index.
  */
 public class SearchIndexValue {
     private final String name;
-    private final MatchType type;
+    private final MatchTypeInterface type;
     private final String path;
 
     /**
@@ -31,7 +31,7 @@ public class SearchIndexValue {
      * @param type Entry type
      * @param path Path to the entry
      */
-    public SearchIndexValue(String name, MatchType type, String path) {
+    public SearchIndexValue(String name, MatchTypeInterface type, String path) {
         this.name = name;
         this.type = type;
         this.path = path;
@@ -49,7 +49,7 @@ public class SearchIndexValue {
      * Get the entry type
      * @return Type
      */
-    public MatchType getType() {
+    public MatchTypeInterface getType() {
         return type;
     }
 

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/DBSupportTest.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/DBSupportTest.java
@@ -1,13 +1,10 @@
 package com.megatome.j2d.support;
 
-import com.megatome.j2d.exception.BuilderException;
-import com.megatome.j2d.util.IndexData;
-import com.megatome.j2d.util.SearchIndexValue;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.apache.commons.io.FileUtils.getFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.sql.Connection;
@@ -18,11 +15,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.io.FileUtils.getFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.megatome.j2d.exception.BuilderException;
+import com.megatome.j2d.util.IndexData;
+import com.megatome.j2d.util.SearchIndexValue;
 
 public class DBSupportTest {
     private static final File javadocLocation = getFile(System.getProperty("j2d-sample-javadoc"));
@@ -34,9 +35,11 @@ public class DBSupportTest {
 
     @Test
     public void testCreateIndexDB() throws Exception {
+        JavadocSupport javadocSupport = new JavadocSupport();
         assertThat(javadocLocation, notNullValue());
-        final IndexData indexData = JavadocSupport.findIndexFile(javadocLocation);
-        final List<SearchIndexValue> indexValues = JavadocSupport.findSearchIndexValues(indexData.getFilesToIndex());
+
+        final IndexData indexData = javadocSupport.findIndexFile(javadocLocation);
+        final List<SearchIndexValue> indexValues = javadocSupport.findSearchIndexValues(indexData.getFilesToIndex());
         final String docFileRoot = FilenameUtils.concat(temporaryFolder.getRoot().getPath(), "Foo");
         final String dbDirName = DocSetSupport.getDBDir(docFileRoot);
         final File dbDir = getFile(dbDirName);

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/JavadocSupportTest.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/JavadocSupportTest.java
@@ -96,7 +96,7 @@ public class JavadocSupportTest {
         final List<SearchIndexValue> indexValues = (new JavadocSupport()).findSearchIndexValues(indexData.getFilesToIndex());
         assertNotNull(indexValues);
         assertThat(indexValues.size(), is(getExpectedData().getExpectedEntryCount()));
-        final Map<MatchTypeInterface, List<String>> valueMap = new HashMap<>();
+        final Map<MatchType, List<String>> valueMap = new HashMap<>();
         for (final SearchIndexValue value: indexValues) {
             List<String> nameSet = valueMap.get(value.getType());
             if (nameSet == null) {
@@ -104,7 +104,7 @@ public class JavadocSupportTest {
             }
             assertThat(nameSet, not(hasItem(value.getName())));
             nameSet.add(value.getName());
-            valueMap.put(value.getType(), nameSet);
+            valueMap.put((MatchType)value.getType(), nameSet);
         }
 
         final Map<MatchType, Integer> expectedTypes = getExpectedData().getExpectedTypes();

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/JavadocSupportTest.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/JavadocSupportTest.java
@@ -96,7 +96,7 @@ public class JavadocSupportTest {
         final List<SearchIndexValue> indexValues = (new JavadocSupport()).findSearchIndexValues(indexData.getFilesToIndex());
         assertNotNull(indexValues);
         assertThat(indexValues.size(), is(getExpectedData().getExpectedEntryCount()));
-        final Map<MatchType, List<String>> valueMap = new HashMap<>();
+        final Map<MatchTypeInterface, List<String>> valueMap = new HashMap<>();
         for (final SearchIndexValue value: indexValues) {
             List<String> nameSet = valueMap.get(value.getType());
             if (nameSet == null) {

--- a/javadoc2dash-api/src/test/java/com/megatome/j2d/support/JavadocSupportTest.java
+++ b/javadoc2dash-api/src/test/java/com/megatome/j2d/support/JavadocSupportTest.java
@@ -1,21 +1,30 @@
 package com.megatome.j2d.support;
 
-import com.megatome.j2d.exception.BuilderException;
-import com.megatome.j2d.util.IndexData;
-import com.megatome.j2d.util.SearchIndexValue;
-import org.junit.Test;
+import static com.megatome.j2d.support.ExpectedDataUtil.getExpectedData;
+import static org.apache.commons.io.FileUtils.getFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static com.megatome.j2d.support.ExpectedDataUtil.getExpectedData;
-import static org.apache.commons.io.FileUtils.getFile;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+import com.megatome.j2d.exception.BuilderException;
+import com.megatome.j2d.util.IndexData;
+import com.megatome.j2d.util.SearchIndexValue;
 
 public class JavadocSupportTest {
     private static final File resourcesRoot = getFile("src", "test", "resources");
@@ -26,17 +35,17 @@ public class JavadocSupportTest {
 
     @Test(expected = BuilderException.class)
     public void testMissingJavadocDir() throws Exception {
-        JavadocSupport.findIndexFile(getFile(resourcesRoot, "FOO"));
+        (new JavadocSupport()).findIndexFile(getFile(resourcesRoot, "FOO"));
     }
 
     @Test(expected = BuilderException.class)
     public void testJavadocDirIsFile() throws Exception {
-        JavadocSupport.findIndexFile(getFile(regularJavadoc, "index.html"));
+        (new JavadocSupport()).findIndexFile(getFile(regularJavadoc, "index.html"));
     }
 
     @Test(expected = BuilderException.class)
     public void testNonJavadocDir() throws Exception {
-        JavadocSupport.findIndexFile(getFile(resourcesRoot, NOT_JAVADOC_DIR));
+        (new JavadocSupport()).findIndexFile(getFile(resourcesRoot, NOT_JAVADOC_DIR));
     }
 
     @Test
@@ -57,7 +66,7 @@ public class JavadocSupportTest {
         final ByteArrayOutputStream errStream = new ByteArrayOutputStream();
         System.setErr(new PrintStream(errStream));
         try {
-            JavadocSupport.findSearchIndexValues(filesToIndex);
+            (new JavadocSupport()).findSearchIndexValues(filesToIndex);
         }
         finally {
             System.setErr(null);
@@ -72,7 +81,7 @@ public class JavadocSupportTest {
     }
 
     private IndexData getAndVerifyIndexFiles(int expectedFileCount, File javadocDir) throws Exception {
-        final IndexData indexData = JavadocSupport.findIndexFile(javadocDir);
+        final IndexData indexData = (new JavadocSupport()).findIndexFile(javadocDir);
         assertNotNull(indexData);
         final String indexFile = indexData.getDocsetIndexFile();
         assertNotNull(indexFile);
@@ -84,7 +93,7 @@ public class JavadocSupportTest {
     }
 
     private void verifyFoundIndexValues(final IndexData indexData) throws Exception {
-        final List<SearchIndexValue> indexValues = JavadocSupport.findSearchIndexValues(indexData.getFilesToIndex());
+        final List<SearchIndexValue> indexValues = (new JavadocSupport()).findSearchIndexValues(indexData.getFilesToIndex());
         assertNotNull(indexValues);
         assertThat(indexValues.size(), is(getExpectedData().getExpectedEntryCount()));
         final Map<MatchType, List<String>> valueMap = new HashMap<>();


### PR DESCRIPTION
The changes introduce two interfaces that can be implemented directly in gradle to provide custom rules on how to fill the DashDocset database. The original JavaDoc to DashDocset is now a specific - and the default - implementation of these interfaces.

I also implemented a sample for JSDoc3 at https://github.com/i-net-software/jsdoc-dash-docset